### PR TITLE
Multiprocessing of Single Train/Test Splits

### DIFF
--- a/test/collaborative_filtering/evaluation/accuracy_test.py
+++ b/test/collaborative_filtering/evaluation/accuracy_test.py
@@ -187,7 +187,8 @@ class AccuracyEvaluationTest(unittest.TestCase):
         yield (self.selected_train_indices_iter, iter(self.selected_test_indices))
 
     def callback_filter_mock(self, matrix, indices, baseValue):
-        assert indices == self.selected_train_indices_iter
+        for first, second in zip(indices, iter(self.selected_train_indices)):
+            assert (first == second).all()
         assert_are_same_matrices(matrix, self.is_rated_matrix)
         assert baseValue == False
 


### PR DESCRIPTION
# What's new
All splits of train-/test-data are now computed simultaneously with the help of multiprocessing.Pool

# Future improvements
The multiprocessing part itself cannot be unit tested right now, because the module isn't able to "pickle" the MagicMock object. Found a related issue [here](https://github.com/testing-cabal/mock/issues/139). A proposed solution is this [multiprocess fork](https://github.com/uqfoundation/multiprocess), but there I ran into this [issue](https://github.com/uqfoundation/multiprocess/issues/61#)

An other solution might be, to mock the Pool.starmap function itself, but I had no time to try that out.

closes #21 