### PR TITLE
Bug/#29 user based evaluation dataset

### DIFF
--- a/collaborative_filtering/evaluation/accuracy.py
+++ b/collaborative_filtering/evaluation/accuracy.py
@@ -8,7 +8,7 @@ import _pickle
 
 from evaluation import EvaluationProperties, EvaluationPropertiesBuilder, selection
 from similarity import similarity
-import prediction.data as data
+from prediction.data import DatasetBuilder
 import prediction.prediction as prediction
 
 
@@ -132,11 +132,13 @@ def _run_single_test_case(train_indices, test_indices, eval_props: SinglePredict
         kept_is_rated_matrix
     )
 
-    dataset = data.dataset(
-        similarity_matrix,
-        eval_props.ratings_matrix,
-        kept_is_rated_matrix
-    )
+    dataset = DatasetBuilder() \
+        .with_similarity_matrix(similarity_matrix) \
+        .with_rating_matrix(eval_props.ratings_matrix, 1) \
+        .with_is_rated_matrix(kept_is_rated_matrix, 1) \
+        .with_approach(eval_props.approach) \
+        .build()
+
     predictions = []
     actual_ratings = []
 

--- a/collaborative_filtering/prediction/data.py
+++ b/collaborative_filtering/prediction/data.py
@@ -1,5 +1,64 @@
 import numpy as np
+import similarity.similarity as similarity
 
+class DatasetBuilder:
+    def __init__(self):
+        self.rating_matrix = None
+        self.is_rated_matrix = None
+        self.similarity_matrix = None
+        self.approach = None
+
+    def with_rating_matrix(self, rating_matrix, user_axis):
+        self.rating_matrix = rating_matrix
+
+        if user_axis != 1:
+            self.rating_matrix = self.rating_matrix.T
+
+        return self
+
+    def with_is_rated_matrix(self, is_rated_matrix, user_axis):
+        self.is_rated_matrix = is_rated_matrix
+
+        if user_axis != 1:
+            self.is_rated_matrix = self.is_rated_matrix.T
+
+        return self
+
+    def with_similarity_matrix(self, similarity_matrix):
+        self.similarity_matrix = similarity_matrix
+        return self
+
+    def with_approach(self, approach):
+        if not approach in [similarity.USER_BASED, similarity.ITEM_BASED]:
+            raise ValueError("approach is not valid")
+        self.approach = approach
+
+        return self
+
+    def build(self):
+        self._check_if_complete()
+        rating_matrix = self.rating_matrix
+        is_rated_matrix = self.is_rated_matrix
+        if self.approach == similarity.USER_BASED:
+            rating_matrix = rating_matrix.T
+            is_rated_matrix = is_rated_matrix.T
+
+
+        return dataset(
+            self.similarity_matrix,
+            rating_matrix,
+            is_rated_matrix
+        )
+
+    def _check_if_complete(self):
+        if self.rating_matrix is None:
+            raise ValueError("Rating Matrix is not initialized")
+        if self.is_rated_matrix is None:
+            raise ValueError("Is Rated Matrix is not initialized")
+        if self.similarity_matrix is None:
+            raise ValueError("Similarity Matrix is not initialized")
+        if self.approach is None:
+            raise ValueError("Approach is not initialized")
 
 class dataset:
     def __init__(self, similarity_matrix: np.ndarray, rating_matrix: np.ndarray, is_rated_matrix: np.ndarray):


### PR DESCRIPTION
As proposed in #29 the dataset can now be build with the DatasetBuilder.
The `run_accuracy_evaluation` uses this builder, so that the matrix gets transposed, when the user-based approach is selected.

Closes #29 